### PR TITLE
Solution11-Identity federation between service providers and identity providers with incompatible identity federation protocols

### DIFF
--- a/scenario11/base-setup.sh
+++ b/scenario11/base-setup.sh
@@ -17,6 +17,7 @@
 #properties
 #TODO:read below property from infra.json file
 appName="travelocity.com"
+appName2="PassiveSTSSampleApp"
 tomcatHost=$tomcatHost
 tomcatPort=$tomcatPort
 tomcatUsername=scriptuser
@@ -31,6 +32,10 @@ SAML2IdPURL="https://$serverHost:$serverPort/samlsso"
 SAML2SPEntityId="$appName"
 SkipURIs="/$appName/index.jsp"
 SAML2IdPEntityId=$serverHost
+
+#PassiveSTSSample properties
+replyUrl="http://$tomcatHost:$tomcatPort/$appName2/index.jsp"
+idpUrl="https://$serverHost:$serverPort/passivests"
 
 #create temporary directory
 mkdir $scriptPath/../temp
@@ -70,6 +75,10 @@ curl -T "travelocity.com.war" "http://$tomcatUsername:$tomcatPassword@$tomcatHos
 #passive sts app
 cp -r $scriptPath/../../apps/PassiveSTSSampleApp $scriptPath/../temp/
 cd $scriptPath/../temp/PassiveSTSSampleApp
+
+#updating PassiveSTSSampleApp web.xml file
+sed -i "/init-param/,/\/init-param/s/localhost:8080/${tomcatHost}:${tomcatPort}/g" $scriptPath/../temp/PassiveSTSSampleApp/src/main/webapp/WEB-INF/web.xml
+sed -i "/init-param/,/\/init-param/s/localhost:9443/${serverHost}:${serverPort}/g" $scriptPath/../temp/PassiveSTSSampleApp/src/main/webapp/WEB-INF/web.xml
 mvn clean install
 
 cp -r $scriptPath/../temp/PassiveSTSSampleApp/target/PassiveSTSSampleApp.war $scriptPath/../temp
@@ -84,9 +93,11 @@ while true
 do
 echo $(date)" Waiting until deploying the app on Tomcat!"
 #STATUS=$(curl -s http://scriptuser:scriptuser@localhost:8080/manager/text/list | grep ${appName})
-if curl -s http://$tomcatUsername:$tomcatPassword@$tomcatHost:$tomcatPort/manager/text/list | grep "${appName}:running"
+if curl -s http://$tomcatUsername:$tomcatPassword@$tomcatHost:$tomcatPort/manager/text/list | grep "${appName}:running" &&
+	curl -s http://$tomcatUsername:$tomcatPassword@$tomcatHost:$tomcatPort/manager/text/list | grep "${appName2}:running"
 then
  echo "Found ${appName} is running on Tomcat"
+ echo "Found ${appName2} is running on Tomcat"
  echo "Done base-setup.sh"
  exit 0
 else

--- a/scenario11/jmeter/01-Scenario-11-Identity-federation-between-sps-and-idps.jmx
+++ b/scenario11/jmeter/01-Scenario-11-Identity-federation-between-sps-and-idps.jmx
@@ -179,167 +179,7 @@
             <stringProp name="Argument.name">callbackHost</stringProp>
             <stringProp name="Argument.value">${__property(callbackHost)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-        </collectionProp>
-      </Arguments>
-      <hashTree/>
-      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Variables" enabled="false">
-        <collectionProp name="Arguments.arguments">
-          <elementProp name="isHost" elementType="Argument">
-            <stringProp name="Argument.name">isHost</stringProp>
-            <stringProp name="Argument.value">localhost</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="isPort" elementType="Argument">
-            <stringProp name="Argument.name">isPort</stringProp>
-            <stringProp name="Argument.value">9443</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="adminCredentials" elementType="Argument">
-            <stringProp name="Argument.name">adminCredentials</stringProp>
-            <stringProp name="Argument.value">YWRtaW46YWRtaW4=</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-            <stringProp name="Argument.desc">base64 encrypted admin credentials</stringProp>
-          </elementProp>
-          <elementProp name="adminusername" elementType="Argument">
-            <stringProp name="Argument.name">adminusername</stringProp>
-            <stringProp name="Argument.value">admin</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="adminpassword" elementType="Argument">
-            <stringProp name="Argument.name">adminpassword</stringProp>
-            <stringProp name="Argument.value">admin</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="spName" elementType="Argument">
-            <stringProp name="Argument.name">spName</stringProp>
-            <stringProp name="Argument.value">travelocity.com</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-            <stringProp name="Argument.desc">SP - Travelocity</stringProp>
-          </elementProp>
-          <elementProp name="spDescription" elementType="Argument">
-            <stringProp name="Argument.name">spDescription</stringProp>
-            <stringProp name="Argument.value">travelocitySP</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-            <stringProp name="Argument.desc">Service Provider Description</stringProp>
-          </elementProp>
-          <elementProp name="carbonServer" elementType="Argument">
-            <stringProp name="Argument.name">carbonServer</stringProp>
-            <stringProp name="Argument.value">travelocity.com</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="tomcatPort" elementType="Argument">
-            <stringProp name="Argument.name">tomcatPort</stringProp>
-            <stringProp name="Argument.value">8080</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="idp2Facebook" elementType="Argument">
-            <stringProp name="Argument.name">idp2Facebook</stringProp>
-            <stringProp name="Argument.value">facebook</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="idp2FacebookDescription" elementType="Argument">
-            <stringProp name="Argument.name">idp2FacebookDescription</stringProp>
-            <stringProp name="Argument.value">FacebookIDP</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="fbClientId" elementType="Argument">
-            <stringProp name="Argument.name">fbClientId</stringProp>
-            <stringProp name="Argument.value">381654242297591</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="fbClientSecret" elementType="Argument">
-            <stringProp name="Argument.name">fbClientSecret</stringProp>
-            <stringProp name="Argument.value">65c65633421002c43929899fc97ae9f3</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="fbScope" elementType="Argument">
-            <stringProp name="Argument.name">fbScope</stringProp>
-            <stringProp name="Argument.value">email</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="fbUserInfoFields" elementType="Argument">
-            <stringProp name="Argument.name">fbUserInfoFields</stringProp>
-            <stringProp name="Argument.value">id,name,gender,email,first_name,last_name,age_range,link</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="idp1Twitter" elementType="Argument">
-            <stringProp name="Argument.name">idp1Twitter</stringProp>
-            <stringProp name="Argument.value">TwitterIdp</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="idp1TwitterDescription" elementType="Argument">
-            <stringProp name="Argument.name">idp1TwitterDescription</stringProp>
-            <stringProp name="Argument.value">This is Twitter Fedarated Idp</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="twitterClientId" elementType="Argument">
-            <stringProp name="Argument.name">twitterClientId</stringProp>
-            <stringProp name="Argument.value">WWdo748rnXiF8BkExp7ziVYNm</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="twitterClientSecret" elementType="Argument">
-            <stringProp name="Argument.name">twitterClientSecret</stringProp>
-            <stringProp name="Argument.value">uaOruL1g2AYaCh5aHBrTKDDuAw6Skl4oq8BiyZsQ7oJw8uk1sW</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="tomcatHost" elementType="Argument">
-            <stringProp name="Argument.name">tomcatHost</stringProp>
-            <stringProp name="Argument.value">192.168.1.8</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="twitterUserName" elementType="Argument">
-            <stringProp name="Argument.name">twitterUserName</stringProp>
-            <stringProp name="Argument.value">supun30old</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="twitterPassword" elementType="Argument">
-            <stringProp name="Argument.name">twitterPassword</stringProp>
-            <stringProp name="Argument.value">Test123@</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="fbUserName" elementType="Argument">
-            <stringProp name="Argument.name">fbUserName</stringProp>
-            <stringProp name="Argument.value">wso2qa@gmail.com</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="fbPassword" elementType="Argument">
-            <stringProp name="Argument.name">fbPassword</stringProp>
-            <stringProp name="Argument.value">Wso2qa@123</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="sp2Name" elementType="Argument">
-            <stringProp name="Argument.name">sp2Name</stringProp>
-            <stringProp name="Argument.value">PassiveSTSSampleApp</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-            <stringProp name="Argument.desc">SP - STS web app</stringProp>
-          </elementProp>
-          <elementProp name="sp2Description" elementType="Argument">
-            <stringProp name="Argument.name">sp2Description</stringProp>
-            <stringProp name="Argument.value">stsSP</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="incorrectFbClientId" elementType="Argument">
-            <stringProp name="Argument.name">incorrectFbClientId</stringProp>
-            <stringProp name="Argument.value">incorrect</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-            <stringProp name="Argument.desc">For negative scenario</stringProp>
-          </elementProp>
-          <elementProp name="idp3Facebook" elementType="Argument">
-            <stringProp name="Argument.name">idp3Facebook</stringProp>
-            <stringProp name="Argument.value">FacebookInvalid</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-            <stringProp name="Argument.desc">Invalid Facebook Idp</stringProp>
-          </elementProp>
-          <elementProp name="idp3FacebookDescription" elementType="Argument">
-            <stringProp name="Argument.name">idp3FacebookDescription</stringProp>
-            <stringProp name="Argument.value">This is an invalid idp</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
-          <elementProp name="passiveSTSuserId" elementType="Argument">
-            <stringProp name="Argument.name">passiveSTSuserId</stringProp>
-            <stringProp name="Argument.value">925979694490619904</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">is.qa.com</stringProp>
           </elementProp>
         </collectionProp>
       </Arguments>
@@ -2577,7 +2417,7 @@ try {
             <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename">/Users/IsuruUyanage/Desktop/commit/identity-test-integration/scenario11/jmeter/t50.jtl</stringProp>
+        <stringProp name="filename"></stringProp>
       </ResultCollector>
       <hashTree/>
       <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
@@ -2613,7 +2453,7 @@ try {
             <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename">/Users/IsuruUyanage/Desktop/commit/identity-test-integration/scenario11/jmeter/solution.jtl</stringProp>
+        <stringProp name="filename"></stringProp>
       </ResultCollector>
       <hashTree/>
     </hashTree>

--- a/scenario11/jmeter/01-Scenario-11-Identity-federation-between-sps-and-idps.jmx
+++ b/scenario11/jmeter/01-Scenario-11-Identity-federation-between-sps-and-idps.jmx
@@ -175,6 +175,172 @@
             <stringProp name="Argument.value">${__property(passiveSTSuserId)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="callbackHost" elementType="Argument">
+            <stringProp name="Argument.name">callbackHost</stringProp>
+            <stringProp name="Argument.value">${__property(callbackHost)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Variables" enabled="false">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="isHost" elementType="Argument">
+            <stringProp name="Argument.name">isHost</stringProp>
+            <stringProp name="Argument.value">localhost</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="isPort" elementType="Argument">
+            <stringProp name="Argument.name">isPort</stringProp>
+            <stringProp name="Argument.value">9443</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="adminCredentials" elementType="Argument">
+            <stringProp name="Argument.name">adminCredentials</stringProp>
+            <stringProp name="Argument.value">YWRtaW46YWRtaW4=</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">base64 encrypted admin credentials</stringProp>
+          </elementProp>
+          <elementProp name="adminusername" elementType="Argument">
+            <stringProp name="Argument.name">adminusername</stringProp>
+            <stringProp name="Argument.value">admin</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="adminpassword" elementType="Argument">
+            <stringProp name="Argument.name">adminpassword</stringProp>
+            <stringProp name="Argument.value">admin</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="spName" elementType="Argument">
+            <stringProp name="Argument.name">spName</stringProp>
+            <stringProp name="Argument.value">travelocity.com</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">SP - Travelocity</stringProp>
+          </elementProp>
+          <elementProp name="spDescription" elementType="Argument">
+            <stringProp name="Argument.name">spDescription</stringProp>
+            <stringProp name="Argument.value">travelocitySP</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">Service Provider Description</stringProp>
+          </elementProp>
+          <elementProp name="carbonServer" elementType="Argument">
+            <stringProp name="Argument.name">carbonServer</stringProp>
+            <stringProp name="Argument.value">travelocity.com</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="tomcatPort" elementType="Argument">
+            <stringProp name="Argument.name">tomcatPort</stringProp>
+            <stringProp name="Argument.value">8080</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="idp2Facebook" elementType="Argument">
+            <stringProp name="Argument.name">idp2Facebook</stringProp>
+            <stringProp name="Argument.value">facebook</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="idp2FacebookDescription" elementType="Argument">
+            <stringProp name="Argument.name">idp2FacebookDescription</stringProp>
+            <stringProp name="Argument.value">FacebookIDP</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="fbClientId" elementType="Argument">
+            <stringProp name="Argument.name">fbClientId</stringProp>
+            <stringProp name="Argument.value">381654242297591</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="fbClientSecret" elementType="Argument">
+            <stringProp name="Argument.name">fbClientSecret</stringProp>
+            <stringProp name="Argument.value">65c65633421002c43929899fc97ae9f3</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="fbScope" elementType="Argument">
+            <stringProp name="Argument.name">fbScope</stringProp>
+            <stringProp name="Argument.value">email</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="fbUserInfoFields" elementType="Argument">
+            <stringProp name="Argument.name">fbUserInfoFields</stringProp>
+            <stringProp name="Argument.value">id,name,gender,email,first_name,last_name,age_range,link</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="idp1Twitter" elementType="Argument">
+            <stringProp name="Argument.name">idp1Twitter</stringProp>
+            <stringProp name="Argument.value">TwitterIdp</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="idp1TwitterDescription" elementType="Argument">
+            <stringProp name="Argument.name">idp1TwitterDescription</stringProp>
+            <stringProp name="Argument.value">This is Twitter Fedarated Idp</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="twitterClientId" elementType="Argument">
+            <stringProp name="Argument.name">twitterClientId</stringProp>
+            <stringProp name="Argument.value">WWdo748rnXiF8BkExp7ziVYNm</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="twitterClientSecret" elementType="Argument">
+            <stringProp name="Argument.name">twitterClientSecret</stringProp>
+            <stringProp name="Argument.value">uaOruL1g2AYaCh5aHBrTKDDuAw6Skl4oq8BiyZsQ7oJw8uk1sW</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="tomcatHost" elementType="Argument">
+            <stringProp name="Argument.name">tomcatHost</stringProp>
+            <stringProp name="Argument.value">192.168.1.8</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="twitterUserName" elementType="Argument">
+            <stringProp name="Argument.name">twitterUserName</stringProp>
+            <stringProp name="Argument.value">supun30old</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="twitterPassword" elementType="Argument">
+            <stringProp name="Argument.name">twitterPassword</stringProp>
+            <stringProp name="Argument.value">Test123@</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="fbUserName" elementType="Argument">
+            <stringProp name="Argument.name">fbUserName</stringProp>
+            <stringProp name="Argument.value">wso2qa@gmail.com</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="fbPassword" elementType="Argument">
+            <stringProp name="Argument.name">fbPassword</stringProp>
+            <stringProp name="Argument.value">Wso2qa@123</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="sp2Name" elementType="Argument">
+            <stringProp name="Argument.name">sp2Name</stringProp>
+            <stringProp name="Argument.value">PassiveSTSSampleApp</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">SP - STS web app</stringProp>
+          </elementProp>
+          <elementProp name="sp2Description" elementType="Argument">
+            <stringProp name="Argument.name">sp2Description</stringProp>
+            <stringProp name="Argument.value">stsSP</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="incorrectFbClientId" elementType="Argument">
+            <stringProp name="Argument.name">incorrectFbClientId</stringProp>
+            <stringProp name="Argument.value">incorrect</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">For negative scenario</stringProp>
+          </elementProp>
+          <elementProp name="idp3Facebook" elementType="Argument">
+            <stringProp name="Argument.name">idp3Facebook</stringProp>
+            <stringProp name="Argument.value">FacebookInvalid</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">Invalid Facebook Idp</stringProp>
+          </elementProp>
+          <elementProp name="idp3FacebookDescription" elementType="Argument">
+            <stringProp name="Argument.name">idp3FacebookDescription</stringProp>
+            <stringProp name="Argument.value">This is an invalid idp</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="passiveSTSuserId" elementType="Argument">
+            <stringProp name="Argument.name">passiveSTSuserId</stringProp>
+            <stringProp name="Argument.value">925979694490619904</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -290,7 +456,7 @@
                &lt;/xsd:properties&gt;&#xd;
                &lt;xsd:properties&gt;&#xd;
                   &lt;xsd:name&gt;callbackUrl&lt;/xsd:name&gt;&#xd;
-                  &lt;xsd:value&gt;https://${isHost}:${isPort}/commonauth&lt;/xsd:value&gt;&#xd;
+                  &lt;xsd:value&gt;https://${callbackHost}:${isPort}/commonauth&lt;/xsd:value&gt;&#xd;
                &lt;/xsd:properties&gt;&#xd;
             &lt;/xsd:federatedAuthenticatorConfigs&gt;&#xd;
          &lt;/mgt:identityProvider&gt;&#xd;
@@ -768,7 +934,8 @@ try {
 		button.click();
 
 		//Returns the whole page
-		return driver.getPageSource();  
+		return driver.getPageSource();
+		 
     
 } catch (Exception ex) {
     ex.printStackTrace();
@@ -907,7 +1074,7 @@ try {
                &lt;/xsd:properties&gt;&#xd;
                &lt;xsd:properties&gt;&#xd;
                   &lt;xsd:name&gt;callBackUrl&lt;/xsd:name&gt;&#xd;
-                  &lt;xsd:value&gt;https://${isHost}:${isPort}/commonauth&lt;/xsd:value&gt;&#xd;
+                  &lt;xsd:value&gt;https://${callbackHost}:${isPort}/commonauth&lt;/xsd:value&gt;&#xd;
                &lt;/xsd:properties&gt;&#xd;
                &lt;xsd:properties&gt;&#xd;
                   &lt;xsd:name&gt;UserInfoFields&lt;/xsd:name&gt;&#xd;
@@ -1111,7 +1278,7 @@ try {
 		String travelocityURL = protocole + tomcathost + seperator + tomcatport + url;
 		
 		driver.get(travelocityURL);
-		driver.manage().timeouts().implicitlyWait(10,TimeUnit.SECONDS);
+		driver.manage().timeouts().implicitlyWait(15,TimeUnit.SECONDS);
 		WebElement link = driver.findElement(By.linkText(&quot;here&quot;));
 		link.click();
 
@@ -1267,7 +1434,7 @@ try {
                &lt;/xsd:properties&gt;&#xd;
                &lt;xsd:properties&gt;&#xd;
                   &lt;xsd:name&gt;callBackUrl&lt;/xsd:name&gt;&#xd;
-                  &lt;xsd:value&gt;https://${isHost}:${isPort}/commonauth&lt;/xsd:value&gt;&#xd;
+                  &lt;xsd:value&gt;https://${callbackHost}:${isPort}/commonauth&lt;/xsd:value&gt;&#xd;
                &lt;/xsd:properties&gt;&#xd;
                &lt;xsd:properties&gt;&#xd;
                   &lt;xsd:name&gt;UserInfoFields&lt;/xsd:name&gt;&#xd;
@@ -1474,8 +1641,6 @@ try {
 
 		WebElement link = driver.findElement(By.linkText(&quot;here&quot;));
 		link.click();
-
-
 
 		//Returns the whole page
 		return driver.getPageSource();  
@@ -1747,7 +1912,7 @@ try {
 		String passiveStsURL = protocole + tomcathost + seperator + tomcatport + url;
 		
 		driver.get(passiveStsURL);
-		driver.manage().timeouts().implicitlyWait(10,TimeUnit.SECONDS);
+		driver.manage().timeouts().implicitlyWait(15,TimeUnit.SECONDS);
 		WebElement username =  driver.findElement(By.id(&quot;username_or_email&quot;));
 		username.clear();
 		username.sendKeys(new String[] { vars.get(&quot;twitterUserName&quot;) });
@@ -1761,7 +1926,7 @@ try {
 
 		//Returns the whole page
 		return driver.getPageSource();  
-		driver.manage().timeouts().implicitlyWait(15,TimeUnit.SECONDS);
+
     
 } catch (Exception ex) {
     ex.printStackTrace();
@@ -1900,9 +2065,7 @@ try {
 		String url = &quot;/PassiveSTSSampleApp/index.jsp&quot;;
 
 		String passiveStsURL = protocole + tomcathost + seperator + tomcatport + url;
-		
 		driver.get(passiveStsURL);
-
 
 		//Returns the whole page
 		return driver.getPageSource();  
@@ -2414,7 +2577,7 @@ try {
             <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename">/Users/IsuruUyanage/Desktop/new/New2/identity-test-integration/scenario11/jmeter/wwwaaaaaaajjj.jtl</stringProp>
+        <stringProp name="filename">/Users/IsuruUyanage/Desktop/commit/identity-test-integration/scenario11/jmeter/t50.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
       <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
@@ -2450,7 +2613,7 @@ try {
             <connectTime>true</connectTime>
           </value>
         </objProp>
-        <stringProp name="filename"></stringProp>
+        <stringProp name="filename">/Users/IsuruUyanage/Desktop/commit/identity-test-integration/scenario11/jmeter/solution.jtl</stringProp>
       </ResultCollector>
       <hashTree/>
     </hashTree>

--- a/scenario11/resources/user.properties
+++ b/scenario11/resources/user.properties
@@ -18,22 +18,22 @@
 #serverHost=localhost
 
 
-serverHost=$serverHost
-serverPort=$serverPort
+serverHost=localhost
+serverPort=9443
 adminCredentials=YWRtaW46YWRtaW4=	
 adminusername=admin
 adminpassword=admin
 spName=travelocity.com
 spDescription=travelocitySP	
 carbonServer=travelocity.com	
-tomcatPort=$tomcatPort
+tomcatPort=8080
 idp2Facebook=facebook	
 idp2FacebookDescription=FacebookIDP	
 fbClientId=381654242297591	
 fbClientSecret=65c65633421002c43929899fc97ae9f3
 fbScope=email	
 fbUserInfoFields=id,name,gender,email,first_name,last_name,age_range,link	
-tomcatHost=$tomcatHost
+tomcatHost=10.100.5.136
 idp1Twitter=TwitterIdp
 idp1TwitterDescription=This is Twitter Fedarated Idp
 twitterClientId=WWdo748rnXiF8BkExp7ziVYNm
@@ -48,4 +48,5 @@ incorrectFbClientId=incorrect
 idp3Facebook=FacebookInvalid
 idp3FacebookDescription=This is an invalid idp
 passiveSTSuserId=925979694490619904
+callbackHost=is.qa.com
 

--- a/scenario11/resources/user.properties
+++ b/scenario11/resources/user.properties
@@ -18,22 +18,22 @@
 #serverHost=localhost
 
 
-serverHost=localhost
-serverPort=9443
+serverHost=$serverHost
+serverPort=$serverPort
 adminCredentials=YWRtaW46YWRtaW4=	
 adminusername=admin
 adminpassword=admin
 spName=travelocity.com
 spDescription=travelocitySP	
 carbonServer=travelocity.com	
-tomcatPort=8080
+tomcatPort=$tomcatPort
 idp2Facebook=facebook	
 idp2FacebookDescription=FacebookIDP	
 fbClientId=381654242297591	
 fbClientSecret=65c65633421002c43929899fc97ae9f3
 fbScope=email	
 fbUserInfoFields=id,name,gender,email,first_name,last_name,age_range,link	
-tomcatHost=10.100.5.136
+tomcatHost=$tomcatHost
 idp1Twitter=TwitterIdp
 idp1TwitterDescription=This is Twitter Fedarated Idp
 twitterClientId=WWdo748rnXiF8BkExp7ziVYNm


### PR DESCRIPTION
## Purpose
Problem:
 -The business users need to login into a SAML service provider with an assertion coming from an OpenID Connect identity provider.

-In other words, the user is authenticated against an identity provider, which only supports OpenID Connect, but the user needs to login into a service provider, which only supports SAML 2.0.

## Goals
> Scenario:

-Represent all the service providers in the WSO2 Identity Server and configure the corresponding inbound authenticators (SAML, OpenID, OIDC, WS-Federation).

-Represent all the identity providers in the WSO2 Identity Server and configure corresponding federated authenticators (SAML, OpenID, OIDC, WS-Federation).

-Associate identity providers with service providers, under the Service Provider configuration, under the Local and Outbound Authentication configuration, irrespective of the protocols they support.
Products: WSO2 Identity Server 5.0.0+

## Approach
> This JMeter script includes following negative and positive scenarios. 
- Create a SAML Service Provider(Travelocity) and log in with OAuth Identity Providers. (Twitter/Facebook)
- Create a Passive STS service provider and log in with OAuth Identity Providers. 
- Negative scenarios have been included as creating an Identity Provider with an invalid clientID and perform above logins. 

## Documentation
> https://docs.wso2.com/display/IS541/Single+Sign-On

## Test environment
> JDK: 1.8.0_144-b01
Tomcat: apache-tomcat-7.0.50
OS: macOS high sierra
 